### PR TITLE
Make a few devcontainer improvements

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/vscode/devcontainers/universal:linux
+FROM mcr.microsoft.com/vscode/devcontainers/universal:latest
 RUN wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key|sudo apt-key add - && \
     sudo add-apt-repository "deb https://apt.llvm.org/focal/ llvm-toolchain-focal-13 main" && \
     sudo apt-get -y update && \

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -16,11 +16,9 @@
         "python.linting.pylintPath": "/usr/local/py-utils/bin/pylint"
         },
     "remoteUser": "codespace",
-    "workspaceMount": "source=${localWorkspaceFolder},target=/home/qat,type=bind,consistency=cached",
-    "workspaceFolder": "/home/qat",
     "extensions": [
         "ms-vscode.cpptools",
         "ms-python.python"
     ],
-    "postCreateCommand": "git submodule update --init --recursive && pip install -r /home/qat/requirements.txt"
+    "postCreateCommand": "git submodule update --init --recursive && pip install -r requirements.txt"
 }


### PR DESCRIPTION
* Switch the universal image tag to `latest` to benefit from caching in Codespaces
* Remove `workspaceMount` and `workspaceFolder` since they are not supported in Codespaces yet
* Update `postCreateCommand` to use a relative path instead of absolute path, which also fixes the issue with the absolute path that was pointing to the unsupported workspaceFolder and was not working because of that